### PR TITLE
Add a pifacedigital_wait_for_input2() that returns wether or not interrupts were triggered

### DIFF
--- a/src/pifacedigital.c
+++ b/src/pifacedigital.c
@@ -140,3 +140,16 @@ uint8_t pifacedigital_wait_for_input(int timeout, uint8_t hw_addr)
     // Read & return input register, thus clearing interrupt
     return pifacedigital_read_reg(0x11, hw_addr);
 }
+
+int pifacedigital_wait_for_input2(uint8_t *data_ptr, int timeout, uint8_t hw_addr)
+{
+    // Flush any pending interrupts prior to wait
+    pifacedigital_read_reg(0x11, hw_addr);
+
+    // Wait for input state change
+    int ret = mcp23s17_wait_for_interrupt(timeout);
+
+    // Read & return input register, thus clearing interrupt
+    *data_ptr = pifacedigital_read_reg(0x11, hw_addr);
+    return ret;
+}

--- a/src/pifacedigital.h
+++ b/src/pifacedigital.h
@@ -197,6 +197,12 @@ int pifacedigital_disable_interrupts();
  */
 uint8_t pifacedigital_wait_for_input(int timeout, uint8_t hw_addr);
 
+/**
+* This is similar to pifacedigital_wait_for_input except for 2 things:
+*     1. The return value is > 0 if some interrupts were triggered. Otherwise it is <= 0.
+*     2. Instead of returning the uint8_t that represent the states of the pins, they are copied into data_ptr;
+*/
+int pifacedigital_wait_for_input2(uint8_t *data_ptr, int timeout, uint8_t hw_addr);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hello,

This PR adds a `pifacedigital_wait_for_input2()` function that allows the caller to know wether or not interrupts were triggered.

It uses the return value from `mcp23s17_wait_for_interrupt()` so I believe the behavior is correct. If it's indeed OK, can you please merge this PR?

Thanks,
