### PR TITLE
Trivial fixes to compile pifacedigital-cmd.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ example-interrupt: example-interrupt.c
 	gcc -o example-interrupt example-interrupt.c -Isrc/ -L. -lpifacedigital -L../libmcp23s17/ -lmcp23s17
 
 pifacedigital: util/pifacedigital-cmd.c
-	gcc -o pifacedigital util/pifacedigital-cmd.c -Isrc/ -I../libmcp23s17/src/ -L. -lpifacedigital -L../libmcp23s17/ -lmcp23s17 -lstderr
+	gcc -o pifacedigital util/pifacedigital-cmd.c -Isrc/ -I../libmcp23s17/src/ -L. -lpifacedigital -L../libmcp23s17/ -lmcp23s17
 
 clean:
 	rm -f $(OBJECTS)

--- a/util/pifacedigital-cmd.c
+++ b/util/pifacedigital-cmd.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     const uint8_t hw_addr = arguments.hw_addr > 0 ? arguments.hw_addr : 0;
     const uint8_t reg = str2reg(arguments.reg);
     if (arguments.bit_num > 7) {
-        sprintf(stderr, "pifacedigital: bit num must in range 0-7.\n");
+        fprintf(stderr, "pifacedigital: bit num must in range 0-7.\n");
         exit(1);
     }
 
@@ -150,7 +150,7 @@ uint8_t str2reg(char * reg_str)
     } else if (strcmp(reg_str, "input") == 0 || strcmp(reg_str, "gpiob") == 0) {
         return GPIOB;
     } else {
-        sprintf(stderr, "pifacedigital: no such register '%s'\n", reg_str);
+        fprintf(stderr, "pifacedigital: no such register '%s'\n", reg_str);
         exit(1);
     }
 }


### PR DESCRIPTION
Use fprintf instead of sprintf, libstderr does not exist.